### PR TITLE
fix issue#5893: (#5992)

### DIFF
--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-common/src/main/java/org/apache/shardingsphere/encrypt/rule/EncryptRule.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-common/src/main/java/org/apache/shardingsphere/encrypt/rule/EncryptRule.java
@@ -167,7 +167,7 @@ public final class EncryptRule implements ShardingSphereRule {
      * @return cipher column or not
      */
     public boolean isCipherColumn(final String tableName, final String columnName) {
-        return tables.containsKey(tableName) && tables.get(tableName).getCipherColumns().contains(columnName);
+        return tables.containsKey(tableName) && tables.get(tableName).getCipherColumns().stream().anyMatch(each -> each.equalsIgnoreCase(columnName));
     }
     
     /**


### PR DESCRIPTION
* fix issue#5893:
EncryptRule use equalsIgnoreCase method to match encrypt column, but use equals method to match decrypt column. #5893

* fix issue#5893:
EncryptRule use equalsIgnoreCase method to match encrypt column, but use equals method to match decrypt column. #5893
remove private function and use java8 lambda to instead of for each.

Fixes #ISSUSE_ID.

Changes proposed in this pull request:
-
-
-
